### PR TITLE
Add get_text_asset tool

### DIFF
--- a/Editor/Tools/GetTextAssetTool.cs
+++ b/Editor/Tools/GetTextAssetTool.cs
@@ -1,0 +1,68 @@
+using System;
+using System.IO;
+using Newtonsoft.Json.Linq;
+using UnityEditor;
+using UnityEngine;
+using McpUnity.Unity;
+using McpUnity.Utils;
+
+namespace McpUnity.Tools
+{
+    /// <summary>
+    /// Tool for reading the contents of a text asset inside the Unity project.
+    /// </summary>
+    public class GetTextAssetTool : McpToolBase
+    {
+        public GetTextAssetTool()
+        {
+            Name = "get_text_asset";
+            Description = "Reads the contents of a text file from the Unity project";
+        }
+
+        /// <summary>
+        /// Execute the GetTextAsset tool with the provided parameters.
+        /// </summary>
+        /// <param name="parameters">Tool parameters as a JObject</param>
+        public override JObject Execute(JObject parameters)
+        {
+            string filePath = parameters["filePath"]?.ToObject<string>();
+
+            if (string.IsNullOrEmpty(filePath))
+            {
+                return McpUnitySocketHandler.CreateErrorResponse(
+                    "Required parameter 'filePath' not provided",
+                    "validation_error"
+                );
+            }
+
+            try
+            {
+                string fullPath = Path.GetFullPath(filePath);
+                if (!File.Exists(fullPath))
+                {
+                    return McpUnitySocketHandler.CreateErrorResponse(
+                        $"File not found at path '{filePath}'",
+                        "file_not_found"
+                    );
+                }
+
+                string contents = File.ReadAllText(fullPath);
+
+                return new JObject
+                {
+                    ["success"] = true,
+                    ["type"] = "text",
+                    ["data"] = contents,
+                    ["path"] = filePath.Replace("\\", "/")
+                };
+            }
+            catch (Exception ex)
+            {
+                return McpUnitySocketHandler.CreateErrorResponse(
+                    $"Failed to read text asset: {ex.Message}",
+                    "file_read_error"
+                );
+            }
+        }
+    }
+}

--- a/Editor/UnityBridge/McpUnityServer.cs
+++ b/Editor/UnityBridge/McpUnityServer.cs
@@ -217,6 +217,9 @@ namespace McpUnity.Unity
             // Register CreateTextAssetTool
             CreateTextAssetTool createTextAssetTool = new CreateTextAssetTool();
             _tools.Add(createTextAssetTool.Name, createTextAssetTool);
+            // Register GetTextAssetTool
+            GetTextAssetTool getTextAssetTool = new GetTextAssetTool();
+            _tools.Add(getTextAssetTool.Name, getTextAssetTool);
 
         }
         

--- a/README-ja.md
+++ b/README-ja.md
@@ -89,6 +89,9 @@ MCP Unityは、Unityの`Library/PackedCache`フォルダーをワークスペー
 - `create_text_asset`: Unityプロジェクトにテキストファイルを作成
   > **例:** "Assets/DocsにREADME.txtファイルを作成"
 
+- `get_text_asset`: Unityプロジェクト内のテキストファイルの内容を取得
+  > **例:** "Assets/Docs/README.txt の内容を表示"
+
 
 ### MCPサーバーリソース
 

--- a/README.md
+++ b/README.md
@@ -94,6 +94,9 @@ The following tools are available for manipulating and querying Unity scenes and
 - `create_text_asset`: Creates a text file inside the Unity project
   > **Example prompt:** "Create a README.txt file in Assets/Docs with custom content"
 
+- `get_text_asset`: Reads the contents of a text file from the Unity project
+  > **Example prompt:** "Show me the contents of Assets/Docs/README.txt"
+
 
 ### MCP Server Resources
 

--- a/README_zh-CN.md
+++ b/README_zh-CN.md
@@ -90,6 +90,9 @@ MCP Unity 通过将 Unity `Library/PackedCache` 文件夹添加到您的工作�
 - `create_text_asset`: 在 Unity 项目中创建文本文件
   > **示例提示:** "在 Assets/Docs 下创建 README.txt 文件"
 
+- `get_text_asset`: 读取 Unity 项目中文本文件的内容
+  > **示例提示:** "查看 Assets/Docs/README.txt 的内容"
+
 
 ### MCP 服务器资源
 

--- a/Server~/build/index.js
+++ b/Server~/build/index.js
@@ -15,6 +15,7 @@ import { registerUpdateGameObjectTool } from './tools/updateGameObjectTool.js';
 import { registerTakeScreenshotTool } from './tools/takeScreenshotTool.js';
 import { registerGetScreenshotFunctionTool } from './tools/getScreenshotFunctionTool.js';
 import { registerCreateTextAssetTool } from './tools/createTextAssetTool.js';
+import { registerGetTextAssetTool } from './tools/getTextAssetTool.js';
 import { registerGetMenuItemsResource } from './resources/getMenuItemResource.js';
 import { registerGetConsoleLogsResource } from './resources/getConsoleLogsResource.js';
 import { registerGetHierarchyResource } from './resources/getScenesHierarchyResource.js';
@@ -55,6 +56,7 @@ registerUpdateGameObjectTool(server, mcpUnity, toolLogger);
 registerTakeScreenshotTool(server, mcpUnity, toolLogger);
 registerGetScreenshotFunctionTool(server, mcpUnity, toolLogger);
 registerCreateTextAssetTool(server, mcpUnity, toolLogger);
+registerGetTextAssetTool(server, mcpUnity, toolLogger);
 // Register all resources into the MCP server
 registerGetTestsResource(server, mcpUnity, resourceLogger);
 registerGetGameObjectResource(server, mcpUnity, resourceLogger);

--- a/Server~/build/tools/getTextAssetTool.d.ts
+++ b/Server~/build/tools/getTextAssetTool.d.ts
@@ -1,0 +1,4 @@
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { McpUnity } from '../unity/mcpUnity.js';
+import { Logger } from '../utils/logger.js';
+export declare function registerGetTextAssetTool(server: McpServer, mcpUnity: McpUnity, logger: Logger): void;

--- a/Server~/build/tools/getTextAssetTool.js
+++ b/Server~/build/tools/getTextAssetTool.js
@@ -1,0 +1,42 @@
+import * as z from 'zod';
+import { McpUnityError, ErrorType } from '../utils/errors.js';
+const toolName = 'get_text_asset';
+const toolDescription = 'Reads the contents of a text file from the Unity project';
+const paramsSchema = z.object({
+    filePath: z
+        .string()
+        .describe('Path of the text file relative to the Unity project (e.g., Assets/MyFolder/file.txt)')
+});
+export function registerGetTextAssetTool(server, mcpUnity, logger) {
+    logger.info(`Registering tool: ${toolName}`);
+    server.tool(toolName, toolDescription, paramsSchema.shape, async (params) => {
+        try {
+            logger.info(`Executing tool: ${toolName}`, params);
+            const result = await toolHandler(mcpUnity, params);
+            logger.info(`Tool execution successful: ${toolName}`);
+            return result;
+        }
+        catch (error) {
+            logger.error(`Tool execution failed: ${toolName}`, error);
+            throw error;
+        }
+    });
+}
+async function toolHandler(mcpUnity, params) {
+    const { filePath } = params;
+    const response = await mcpUnity.sendRequest({
+        method: toolName,
+        params: { filePath }
+    });
+    if (!response.success) {
+        throw new McpUnityError(ErrorType.TOOL_EXECUTION, response.message || `Failed to read text asset`);
+    }
+    return {
+        content: [
+            {
+                type: 'text',
+                text: response.data || ''
+            }
+        ]
+    };
+}

--- a/Server~/src/index.ts
+++ b/Server~/src/index.ts
@@ -17,6 +17,7 @@ import { registerTakeScreenshotTool } from './tools/takeScreenshotTool.js';
 import { registerGetScreenshotFunctionTool } from './tools/getScreenshotFunctionTool.js';
 
 import { registerCreateTextAssetTool } from './tools/createTextAssetTool.js';
+import { registerGetTextAssetTool } from './tools/getTextAssetTool.js';
 
 import { registerGetMenuItemsResource } from './resources/getMenuItemResource.js';
 import { registerGetConsoleLogsResource } from './resources/getConsoleLogsResource.js';
@@ -67,6 +68,7 @@ registerTakeScreenshotTool(server, mcpUnity, toolLogger);
 registerGetScreenshotFunctionTool(server, mcpUnity, toolLogger);
 
 registerCreateTextAssetTool(server, mcpUnity, toolLogger);
+registerGetTextAssetTool(server, mcpUnity, toolLogger);
 
 
 // Register all resources into the MCP server

--- a/Server~/src/tools/getTextAssetTool.ts
+++ b/Server~/src/tools/getTextAssetTool.ts
@@ -1,0 +1,68 @@
+import * as z from 'zod';
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { McpUnity } from '../unity/mcpUnity.js';
+import { Logger } from '../utils/logger.js';
+import { McpUnityError, ErrorType } from '../utils/errors.js';
+import { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
+
+const toolName = 'get_text_asset';
+const toolDescription = 'Reads the contents of a text file from the Unity project';
+
+const paramsSchema = z.object({
+  filePath: z
+    .string()
+    .describe('Path of the text file relative to the Unity project (e.g., Assets/MyFolder/file.txt)')
+});
+
+export function registerGetTextAssetTool(
+  server: McpServer,
+  mcpUnity: McpUnity,
+  logger: Logger
+) {
+  logger.info(`Registering tool: ${toolName}`);
+
+  server.tool(
+    toolName,
+    toolDescription,
+    paramsSchema.shape,
+    async (params: z.infer<typeof paramsSchema>) => {
+      try {
+        logger.info(`Executing tool: ${toolName}`, params);
+        const result = await toolHandler(mcpUnity, params);
+        logger.info(`Tool execution successful: ${toolName}`);
+        return result;
+      } catch (error) {
+        logger.error(`Tool execution failed: ${toolName}`, error);
+        throw error;
+      }
+    }
+  );
+}
+
+async function toolHandler(
+  mcpUnity: McpUnity,
+  params: z.infer<typeof paramsSchema>
+): Promise<CallToolResult> {
+  const { filePath } = params;
+
+  const response = await mcpUnity.sendRequest({
+    method: toolName,
+    params: { filePath }
+  });
+
+  if (!response.success) {
+    throw new McpUnityError(
+      ErrorType.TOOL_EXECUTION,
+      response.message || `Failed to read text asset`
+    );
+  }
+
+  return {
+    content: [
+      {
+        type: 'text',
+        text: response.data || ''
+      }
+    ]
+  };
+}


### PR DESCRIPTION
## Summary
- add `get_text_asset` tool to Node server and Unity
- wire up tool registration in server and bridge
- document `get_text_asset` in English, Chinese and Japanese READMEs

## Testing
- `npm run build`